### PR TITLE
Add `labels` to issue template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Report something that is broken or incorrect
+labels: bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: Feature request
 description: Propose a new feature for mulink
+labels: enhancement
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
Change `type` to `labels` in issue template (`type` broke the issue template, see #1 ). 