### PR TITLE
Query functionality 

### DIFF
--- a/src/mulink/basic.py
+++ b/src/mulink/basic.py
@@ -1,9 +1,14 @@
 """Main entrypoint for mulink"""
 
+from collections.abc import Callable
+
 import mudata as md
+import numpy as np
 import pandas as pd
 from mudata import register_mudata_namespace
 from scipy.sparse import csr_matrix
+
+from .query import get_ancestors, get_descendants
 
 
 @register_mudata_namespace("link")
@@ -12,6 +17,56 @@ class MuLink:
 
     def __init__(self, mdata: md.MuData):
         self._obj = mdata
+
+    def _query(
+        self,
+        query_func: Callable[[np.ndarray, csr_matrix], np.ndarray],
+        features: str | list[str],
+        *,
+        key: str = "feature_mapping",
+        include_self: bool = True,
+    ) -> md.MuData:
+        adjacency_matrix = self._obj.varp[key]
+
+        features = [features] if isinstance(features, str) else features
+        query_indices = self._obj.var_names.get_indexer(features)
+
+        result_indices = query_func(vertices=query_indices, adjacency_matrix=adjacency_matrix)
+
+        if include_self:
+            result_indices = np.concatenate([query_indices, result_indices])
+
+        return self._obj[:, self._obj.var_names[result_indices]]
+
+    def query_descendants(
+        self,
+        features: str | list[str],
+        *,
+        key: str = "feature_mapping",
+        include_self: bool = True,
+    ) -> md.MuData:
+        """Get direct descendants of features"""
+        return self._query(
+            query_func=get_descendants,
+            features=features,
+            key=key,
+            include_self=include_self,
+        )
+
+    def query_ancestors(
+        self,
+        features: str | list[str],
+        *,
+        key: str = "feature_mapping",
+        include_self: bool = True,
+    ) -> md.MuData:
+        """Get direct ancestors of features"""
+        return self._query(
+            query_func=get_ancestors,
+            features=features,
+            key=key,
+            include_self=include_self,
+        )
 
     def add_link(self, link: csr_matrix, *, key: str = "feature_mapping") -> None:
         """Add a feature link to mudata"""

--- a/src/mulink/query.py
+++ b/src/mulink/query.py
@@ -1,10 +1,12 @@
 """Query an adjacency matrix"""
 
+from collections.abc import Iterable
+
 import numpy as np
 from scipy.sparse import csr_matrix
 
 
-def get_descendants(vertices: int | list[int], adjacency_matrix: csr_matrix) -> np.ndarray:
+def get_descendants(vertices: int | Iterable[int], adjacency_matrix: csr_matrix) -> np.ndarray:
     """Get all direct descendants for a feature or a list of features
 
     A direct descendants represents a vertix that can be reached by a single hop along the
@@ -31,7 +33,7 @@ def get_descendants(vertices: int | list[int], adjacency_matrix: csr_matrix) -> 
     return np.unique(cols)
 
 
-def get_ancestors(vertices: int | list[int], adjacency_matrix: csr_matrix) -> np.ndarray:
+def get_ancestors(vertices: int | Iterable[int], adjacency_matrix: csr_matrix) -> np.ndarray:
     """Get all direct ancestors for a feature or a list of features
 
     A direct ancestors represents a vertix that can be reached by a single hop against

--- a/src/mulink/query.py
+++ b/src/mulink/query.py
@@ -1,0 +1,50 @@
+"""Query an adjacency matrix"""
+
+import numpy as np
+from scipy.sparse import csr_matrix
+
+
+def get_descendants(vertices: int | list[int], adjacency_matrix: csr_matrix) -> np.ndarray:
+    """Get all direct descendants for a feature or a list of features
+
+    A direct descendants represents a vertix that can be reached by a single hop along the
+    edge directionality.
+
+    Parameters
+    ----------
+    vertices
+        List of vertices for which the descendants should be queried.
+    adjacency_matrix
+        Adjacency matrix which indicates that u -> v (u maps to v)
+        if (u, v) is nonzero.
+
+    Returns
+    -------
+    List of direct successors of the provided vertices
+    """
+    # For an adjacency matrix following networkx convention, finding
+    # all successors of a vertix corresponds to finding the columns containing nonzero `columns`
+    # in the `row` corresponding to the vertix
+    _, cols = adjacency_matrix[vertices, :].nonzero()
+
+    # N:M mapping might yield redundant features - only return unique features
+    return np.unique(cols)
+
+
+def get_ancestors(vertices: int | list[int], adjacency_matrix: csr_matrix) -> np.ndarray:
+    """Get all direct ancestors for a feature or a list of features
+
+    A direct ancestors represents a vertix that can be reached by a single hop against
+    edge directionality.
+
+    Returns
+    -------
+    List of direct ancestors of the provided vertices
+    """
+    # For an adjacency matrix following networkx convention, finding
+    # all ancestors of a vertix corresponds to finding the columns containing nonzero `columns`
+    # in the `row` corresponding to the vertix
+    rows, _ = adjacency_matrix[:, vertices].nonzero()
+
+    # N:M mapping might yield redundant features - only return unique features
+    return np.unique(rows)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -36,6 +36,35 @@ def simple_mudata() -> md.MuData:
     return mdata
 
 
+@pytest.fixture
+def n_to_m_mudata() -> md.MuData:
+    """2-modality MuData with N:M mapping: gene_A -> prot_C, gene_A -> prot_D, gene_B -> prot_D"""
+    gene = ad.AnnData(
+        X=np.array([[1, 2], [3, 4]]),
+        var=pd.DataFrame(index=["gene_A", "gene_B"]),
+        obs=pd.DataFrame(index=["cell_1", "cell_2"]),
+    )
+
+    prot = ad.AnnData(X=np.array([[5, 6], [7, 8]]))
+    prot.var_names = ["prot_C", "prot_D"]
+    prot.obs_names = ["cell_1", "cell_2"]
+
+    mdata = md.MuData({"gene": gene, "prot": prot})
+    # var_names: [gene_A, gene_B, prot_C, prot_D]
+    adj = csr_matrix(
+        np.array(
+            [
+                [0, 0, 1, 1],
+                [0, 0, 0, 1],
+                [0, 0, 0, 0],
+                [0, 0, 0, 0],
+            ]
+        )
+    )
+    mdata.varp["feature_mapping"] = adj
+    return mdata
+
+
 class TestAddLink:
     def test_stores_in_varp(self) -> None:
         rna = ad.AnnData(np.array([[1, 2]]))
@@ -76,3 +105,70 @@ class TestLink:
         expected = simple_mudata.varp["feature_mapping"].toarray()
 
         np.testing.assert_array_equal(result.values, expected)
+
+
+class TestQueryDescendants:
+    def test_single_feature_string(self, simple_mudata) -> None:
+        result = simple_mudata.link.query_descendants("gene_A")
+
+        assert isinstance(result, md.MuData)
+        assert result.n_obs == simple_mudata.n_obs
+
+        assert_array_equal(sorted(result.var_names), ["gene_A", "prot_C"])
+
+    def test_single_feature_list(self, simple_mudata) -> None:
+        result = simple_mudata.link.query_descendants(["gene_A"])
+
+        assert_array_equal(sorted(result.var_names), ["gene_A", "prot_C"])
+
+    def test_multiple_features(self, simple_mudata) -> None:
+        result = simple_mudata.link.query_descendants(["gene_A", "gene_B"])
+
+        assert isinstance(result, md.MuData)
+        assert result.n_obs == simple_mudata.n_obs
+
+        assert_array_equal(sorted(result.var_names), ["gene_A", "gene_B", "prot_C", "prot_D"])
+
+    def test_include_self_true(self, simple_mudata) -> None:
+        result = simple_mudata.link.query_descendants("gene_A", include_self=True)
+
+        assert "gene_A" in result.var_names
+
+    def test_include_self_false(self, simple_mudata) -> None:
+        result = simple_mudata.link.query_descendants("gene_A", include_self=False)
+
+        assert "gene_A" not in result.var_names
+        assert_array_equal(list(result.var_names), ["prot_C"])
+
+    def test_n_to_m_mapping(self, n_to_m_mudata) -> None:
+        result = n_to_m_mudata.link.query_descendants("gene_A", include_self=False)
+
+        assert_array_equal(sorted(result.var_names), ["prot_C", "prot_D"])
+
+
+class TestQueryAncestors:
+    def test_single_feature(self, simple_mudata):
+        result = simple_mudata.link.query_ancestors("prot_C")
+
+        assert isinstance(result, md.MuData)
+        assert result.n_obs == simple_mudata.n_obs
+
+        assert_array_equal(sorted(result.var_names), ["gene_A", "prot_C"])
+
+    def test_include_self_false(self, simple_mudata):
+        result = simple_mudata.link.query_ancestors("prot_C", include_self=False)
+
+        assert result.n_obs == simple_mudata.n_obs
+
+        assert "prot_C" not in result.var_names
+        assert_array_equal(list(result.var_names), ["gene_A"])
+
+    def test_all_observations_preserved(self, simple_mudata):
+        result = simple_mudata.link.query_ancestors("prot_C")
+
+        assert result.shape[0] == simple_mudata.shape[0]
+
+    def test_n_to_m_shared_ancestors(self, n_to_m_mudata):
+        result = n_to_m_mudata.link.query_ancestors("prot_D", include_self=False)
+
+        assert_array_equal(sorted(result.var_names), ["gene_A", "gene_B"])


### PR DESCRIPTION
Add querying of ancestors and successors

```python
# Syntax 
# returns mudata
subset = mdata.link.query_ancestors(["feature1", "feature2"], include_self=True)

# Get a certain modality with built-in mudata syntax (returns anndata)
subset.mod["modX"]
```

## Implementation
For an adjacency matrix following networkx convention, finding all _successors_ of a vertix corresponds to finding the `columns` containing nonzero values in the `row` corresponding to the vertix. 

For an adjacency matrix following networkx convention, finding all _ancestors_ of a vertix corresponds to finding the `rows` containing nonzero values in the `column` corresponding to the vertix. 