### PR TITLE
Synthetic hierarchical data 

### DIFF
--- a/docs/notebooks/example.ipynb
+++ b/docs/notebooks/example.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mulink\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/lucas-diedrich/mamba/envs/mulink/lib/python3.13/site-packages/mudata/_core/mudata.py:1416: FutureWarning: From 0.4 .update() will not pull obs/var columns from individual modalities by default anymore. Set mudata.set_options(pull_on_update=False) to adopt the new behaviour, which will become the default. Use new pull_obs/pull_var and push_obs/push_var methods for more flexibility.\n",
+      "  self._update_attr(\"var\", axis=0, join_common=join_common)\n",
+      "/Users/lucas-diedrich/mamba/envs/mulink/lib/python3.13/site-packages/mudata/_core/mudata.py:1272: FutureWarning: From 0.4 .update() will not pull obs/var columns from individual modalities by default anymore. Set mudata.set_options(pull_on_update=False) to adopt the new behaviour, which will become the default. Use new pull_obs/pull_var and push_obs/push_var methods for more flexibility.\n",
+      "  self._update_attr(\"obs\", axis=1, join_common=join_common)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre>MuData object with n_obs × n_vars = 5 × 14\n",
+       "  varp:\t&#x27;feature_mapping&#x27;\n",
+       "  3 modalities\n",
+       "    mod0:\t5 × 2\n",
+       "    mod1:\t5 × 4\n",
+       "    mod2:\t5 × 8</pre>"
+      ],
+      "text/plain": [
+       "MuData object with n_obs × n_vars = 5 × 14\n",
+       "  varp:\t'feature_mapping'\n",
+       "  3 modalities\n",
+       "    mod0:\t5 × 2\n",
+       "    mod1:\t5 × 4\n",
+       "    mod2:\t5 × 8"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mdata = mulink.simulate.hierarchical_mudata(n_mod=3)\n",
+    "mdata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x12248f0e0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaAAAAGdCAYAAABU0qcqAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAFzVJREFUeJzt3XuMFfXd+PHPArJQAitgBTaCUkODCuIV4yUtRiLhRxF/jVoNVoJJ27RYRROLtAVrvKza1hCR4CWp2kS8/CFizaOGokiMIAJiNG25RIIbCVIT3QUM6wrnyczzsD9XQX7Ys3x3Zl+vZLKeyzJzPLvnfb4z3zNbU6lUKgEAR1i3I71CABAgAJIxAgIgCQECIAkBAiAJAQIgCQECIAkBAiCJHtHJ7Nu3L7Zt2xZ9+/aNmpqa1JsDwGHKzm+wc+fOqK+vj27duhUnQFl8hg4dmnozAPgPNTY2xnHHHVecAGUjn8wF8X+iRxwVZbF447tRNv/3+6OjTMr4HJVR2X7uyuiLaI3X47/aXs8LE6D9u92y+PSoKU+A+vUt3+G2Mj0/ZX2OyqhsP3el9L9nGD3UYRS/cQAkIUAAJCFAACQhQAAkIUAAJCFAAJQrQAsWLIgTTjghevXqFeecc06sXr26o1YFQAF1SICefvrpuOmmm+LWW2+NdevWxZgxY2LChAmxY8eOjlgdAAXUIQG677774mc/+1lMnz49Tj755HjwwQfjO9/5TvzlL3/piNUBUEBVD9Dnn38ea9eujfHjx/+/lXTrll9euXLl1+7f0tISzc3N7RYAyq/qAfr4449j7969MWjQoHbXZ5e3b9/+tfs3NDREXV1d2+JEpABdQ/JZcLNnz46mpqa2JTt7KgDlV/WTkR5zzDHRvXv3+Oijj9pdn10ePHjw1+5fW1ubLwB0LVUfAfXs2TPOPPPMWLZsWbs/MpddPvfcc6u9OgAKqkP+HEM2BXvatGlx1llnxdixY2PevHmxe/fufFYcAHRYgH7yk5/Ev//975g7d24+8eC0006Ll1566WsTEwDoujrsD9Jdd911+QIAnXIWHABdkwABkIQAAZCEAAGQhAABUK5ZcKQxof60I7aul7etP2Lr4tsp48+Dn7vOr3nnvuj//UPfzwgIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECAABAqDrMAICIAkBAiCJHmlW2/VMqD8tyqZsj+nlbetTb0Khle3ngW/vi0prRLx/yPsZAQGQhAABkIQAAZCEAAGQhAABkIQAAZCEAAGQhAABkIQAAVCOADU0NMTZZ58dffv2jWOPPTYuvfTS2LBhQ7VXA0DBVT1Ar732WsyYMSNWrVoVS5cujdbW1rj44otj9+7d1V4VAAVW9XPBvfTSS+0uP/bYY/lIaO3atfGDH/yg2qsDoKA6/GSkTU1N+dcBAwYc8PaWlpZ82a+5ubmjNwmAsk9C2LdvX8ycOTPOP//8GDVq1EGPGdXV1bUtQ4cO7chNAqArBCg7FvTee+/FU089ddD7zJ49Ox8l7V8aGxs7cpMAKPsuuOuuuy5eeOGFWLFiRRx33HEHvV9tbW2+ANC1VD1AlUolfv3rX8fixYtj+fLlMXz48GqvAoAS6NERu90WLVoUS5YsyT8LtH379vz67PhO7969q706AAqq6seAFi5cmB/LGTduXAwZMqRtefrpp6u9KgAKrEN2wQHAoTgXHABJCBAASQgQAEkIEABJCBAA5TwZKRTFhPrTjti6Xt62vlTrKevzRMcyAgIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIIkeaVYLHAkT6k87Yv+jX962vlTrKevz1JkYAQGQhAABIEAAdB1GQAAkIUAAJCFAACQhQAAkIUAAlDNAd999d9TU1MTMmTM7elUAFEiHBuitt96Khx56KE499dSOXA0ABdRhAdq1a1dMnTo1Hnnkkejfv39HrQaAguqwAM2YMSMmTZoU48eP/8b7tbS0RHNzc7sFgPLrkJORPvXUU7Fu3bp8F9yhNDQ0xG233dYRmwFAVxoBNTY2xg033BBPPPFE9OrV65D3nz17djQ1NbUt2fcDUH5VHwGtXbs2duzYEWeccUbbdXv37o0VK1bEAw88kO9y6969e9tttbW1+QJA11L1AF100UXx7rvvtrtu+vTpMXLkyJg1a1a7+ADQdVU9QH379o1Ro0a1u65Pnz4xcODAr10PQNflTAgAlPdPci9fvvxIrAaAAjECAiAJAQIgCQECIAkBAiAJAQIgCQECoLzTsIH2JtSf5n9JARyp5+nlbeujTJp37ov+3z/0/YyAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIokea1QJlM6H+tNSbUFgTSvb/7otKa0S8f8j7GQEBkIQAAZCEAAGQhAABkIQAAZCEAAGQhAABkIQAAZBEhwToww8/jKuvvjoGDhwYvXv3jtGjR8eaNWs6YlUAFFTVz4TwySefxPnnnx8XXnhhvPjii/Hd7343Nm3aFP3796/2qgAosKoH6J577omhQ4fGo48+2nbd8OHDq70aAAqu6rvgnn/++TjrrLPi8ssvj2OPPTZOP/30eOSRRw56/5aWlmhubm63AFB+VQ/Q+++/HwsXLowRI0bEyy+/HL/85S/j+uuvj8cff/yA929oaIi6urq2JRs9AVB+NZVKpVLNf7Bnz575COiNN95ouy4L0FtvvRUrV6484AgoW/bLRkBZhMbFlOhRc1Q1Nw2AI3Q27OWxJJqamqJfv35HbgQ0ZMiQOPnkk9tdd9JJJ8UHH3xwwPvX1tbmG/jlBYDyq3qAshlwGzZsaHfdxo0b4/jjj6/2qgAosKoH6MYbb4xVq1bFXXfdFZs3b45FixbFww8/HDNmzKj2qgAosKoH6Oyzz47FixfHk08+GaNGjYrbb7895s2bF1OnTq32qgAosA75k9w/+tGP8gUADsa54ABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAChHgPbu3Rtz5syJ4cOHR+/evePEE0+M22+/PSqVSrVXBUCB9aj2P3jPPffEwoUL4/HHH49TTjkl1qxZE9OnT4+6urq4/vrrq706AAqq6gF64403YsqUKTFp0qT88gknnBBPPvlkrF69utqrAqDAqr4L7rzzzotly5bFxo0b88vvvPNOvP766zFx4sQD3r+lpSWam5vbLQCUX9VHQLfccksekZEjR0b37t3zY0J33nlnTJ069YD3b2hoiNtuu63amwFAVxsBPfPMM/HEE0/EokWLYt26dfmxoD/96U/51wOZPXt2NDU1tS2NjY3V3iQAusII6Oabb85HQVdeeWV+efTo0bF169Z8pDNt2rSv3b+2tjZfAOhaqj4C+uyzz6Jbt/b/bLYrbt++fdVeFQAFVvUR0OTJk/NjPsOGDcunYb/99ttx3333xbXXXlvtVQFQYFUP0Pz58/MPov7qV7+KHTt2RH19ffziF7+IuXPnVntVABRYTaWTnaIgm0GXfWh1XEyJHjVHpd4cAA7TF5XWWB5L8oll/fr1O+j9nAsOgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAYgRoxYoVMXny5Kivr4+ampp47rnn2t1eqVRi7ty5MWTIkOjdu3eMHz8+Nm3aVM1tBqArBmj37t0xZsyYWLBgwQFvv/fee+P++++PBx98MN58883o06dPTJgwIfbs2VON7QWgJHoc7jdMnDgxXw4kG/3Mmzcvfv/738eUKVPy6/7617/GoEGD8pHSlVde+Z9vMQClUNVjQFu2bInt27fnu932q6uri3POOSdWrlx5wO9paWmJ5ubmdgsA5VfVAGXxyWQjni/LLu+/7asaGhrySO1fhg4dWs1NAqCTSj4Lbvbs2dHU1NS2NDY2pt4kAIoWoMGDB+dfP/roo3bXZ5f33/ZVtbW10a9fv3YLAOVX1QANHz48D82yZcvarsuO6WSz4c4999xqrgqArjYLbteuXbF58+Z2Ew/Wr18fAwYMiGHDhsXMmTPjjjvuiBEjRuRBmjNnTv6ZoUsvvbTa2w5AVwrQmjVr4sILL2y7fNNNN+Vfp02bFo899lj85je/yT8r9POf/zw+/fTTuOCCC+Kll16KXr16VXfLASi0mkr24Z1OJNtll82GGxdTokfNUak3B4DD9EWlNZbHknxi2Tcd108+Cw6ArkmAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgABIQoAASEKAAEhCgAAoRoBWrFgRkydPjvr6+qipqYnnnnuu7bbW1taYNWtWjB49Ovr06ZPf55prrolt27ZVe7sB6GoB2r17d4wZMyYWLFjwtds+++yzWLduXcyZMyf/+uyzz8aGDRvikksuqdb2AlASPQ73GyZOnJgvB1JXVxdLly5td90DDzwQY8eOjQ8++CCGDRv27bcUgK4doMPV1NSU76o7+uijD3h7S0tLvuzX3Nzc0ZsEQNknIezZsyc/JnTVVVdFv379DnifhoaGfOS0fxk6dGhHbhIAZQ9QNiHhiiuuiEqlEgsXLjzo/WbPnp2PkvYvjY2NHbVJAJR9F9z++GzdujVeeeWVg45+MrW1tfkCQNfSo6Pis2nTpnj11Vdj4MCB1V4FAF0xQLt27YrNmze3Xd6yZUusX78+BgwYEEOGDInLLrssn4L9wgsvxN69e2P79u35/bLbe/bsWd2tB6CwairZQZrDsHz58rjwwgu/dv20adPiD3/4QwwfPvyA35eNhsaNG3fIfz+bBZdNRhgXU6JHzVGHs2kAdAJfVFpjeSzJj+t/0yGYwx4BZRH5pmYdZs8A6KKcCw6AJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJHpEJ1OpVPKvX0RrxP/8JwAFkr9+f+n1vDAB2rlzZ/719fiv1JsCwH/4el5XV3fQ22sqh0rUEbZv377Ytm1b9O3bN2pqav6/v6+5uTmGDh0ajY2N0a9fvyi6sj2ejMdUDJ6nzq+5k78+ZFnJ4lNfXx/dunUrzggo29jjjjvuW39/9mR0xifk2yrb48l4TMXgeer8+nXi14dvGvnsZxICAEkIEABJlCZAtbW1ceutt+Zfy6BsjyfjMRWD56nzqy3J60Onm4QAQNdQmhEQAMUiQAAkIUAAJCFAACRRigAtWLAgTjjhhOjVq1ecc845sXr16iiqhoaGOPvss/MzQRx77LFx6aWXxoYNG6Is7r777vwMFzNnzoyi+/DDD+Pqq6+OgQMHRu/evWP06NGxZs2aKKK9e/fGnDlzYvjw4fljOfHEE+P2228/5Lm8OpMVK1bE5MmT80/fZz9jzz33XLvbs8cyd+7cGDJkSP4Yx48fH5s2bYqiPqbW1taYNWtW/nPXp0+f/D7XXHNNfiaZoih8gJ5++um46aab8imJ69atizFjxsSECRNix44dUUSvvfZazJgxI1atWhVLly7Nf8guvvji2L17dxTdW2+9FQ899FCceuqpUXSffPJJnH/++XHUUUfFiy++GP/4xz/iz3/+c/Tv3z+K6J577omFCxfGAw88EP/85z/zy/fee2/Mnz8/iiL7Hcl+/7M3pAeSPZ77778/HnzwwXjzzTfzF+3stWLPnj1RxMf02Wef5a952RuH7Ouzzz6bv1m95JJLojAqBTd27NjKjBkz2i7v3bu3Ul9fX2loaKiUwY4dO7K3oJXXXnutUmQ7d+6sjBgxorJ06dLKD3/4w8oNN9xQKbJZs2ZVLrjggkpZTJo0qXLttde2u+7HP/5xZerUqZUiyn5nFi9e3HZ53759lcGDB1f++Mc/tl336aefVmpraytPPvlkpYiP6UBWr16d32/r1q2VIij0COjzzz+PtWvX5kPpL59LLru8cuXKKIOmpqb864ABA6LIslHdpEmT2j1XRfb888/HWWedFZdffnm+q/T000+PRx55JIrqvPPOi2XLlsXGjRvzy++88068/vrrMXHixCiDLVu2xPbt29v9/GXnKst22ZfltWL/60W2q+7oo4+OIuh0JyM9HB9//HG+73rQoEHtrs8u/+tf/4qiy84Mnh0ryXb1jBo1KorqqaeeyncRZLvgyuL999/Pd1llu39/+9vf5o/t+uuvj549e8a0adOiaG655Zb8DMsjR46M7t27579Xd955Z0ydOjXKIItP5kCvFftvK7o9e/bkx4SuuuqqTnuC0lIFqOyyUcN7772XvxMtqux08TfccEN+PCubJFIW2ZuDbAR011135ZezEVD2XGXHF4oYoGeeeSaeeOKJWLRoUZxyyimxfv36/M1PdmC7iI+nq2ltbY0rrrgin2iRvTEqikLvgjvmmGPyd2sfffRRu+uzy4MHD44iu+666+KFF16IV1999T/68xSpZbtIswkhZ5xxRvTo0SNfsokW2cHg7L+zd9pFlM2kOvnkk9tdd9JJJ8UHH3wQRXTzzTfno6Arr7wyn1X105/+NG688cZ8VmYZ7H89KONrRev/xmfr1q35G72ijH4KH6Bsd8eZZ56Z77v+8jvT7PK5554bRZS9g8nis3jx4njllVfyabFFdtFFF8W7776bv6Pev2Qjh2zXTvbf2RuIIsp2i351enx2/OT444+PIspmVH31D4dlz032+1QG2e9RFpovv1Zkuxyz2XBFfa34cnyy6eR///vf848EFEnhd8Fl++CzXQTZi9rYsWNj3rx5+dTF6dOnR1F3u2W7QZYsWZJ/Fmj//unsgGn22YWiyR7DV49fZdNfs1+UIh/XykYH2YH7bBdc9gKQffbs4Ycfzpciyj5rkh3zGTZsWL4L7u2334777rsvrr322iiKXbt2xebNm9tNPMje5GQTeLLHle1SvOOOO2LEiBF5kLLpy9kuxuyzdkV8TEOGDInLLrssP76a7S3J9ibsf73Ibs/eoHd6lRKYP39+ZdiwYZWePXvm07JXrVpVKarsKTnQ8uijj1bKogzTsDN/+9vfKqNGjcqn8o4cObLy8MMPV4qqubk5f06y36NevXpVvve971V+97vfVVpaWipF8eqrrx7wd2fatGltU7HnzJlTGTRoUP6cXXTRRZUNGzZUivqYtmzZctDXi+z7isCfYwAgiUIfAwKguAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIAkBAiAJAQIgCQECIBI4b8BfPRJyyA2usgAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(mdata.varp[\"feature_mapping\"].toarray())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mulink",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "mudata",
+  "networkx",
   # for debug logging (referenced from the issue template)
   "session-info2",
 ]

--- a/src/mulink/__init__.py
+++ b/src/mulink/__init__.py
@@ -1,3 +1,8 @@
 from importlib.metadata import version
 
+from . import simulate
+
 __version__ = version("mulink")
+
+
+__all__ = ["simulate"]

--- a/src/mulink/simulate.py
+++ b/src/mulink/simulate.py
@@ -1,4 +1,4 @@
-"""Simulate artificial mudata"""
+"""Simulate artificial mudata with explicit feature relationship"""
 
 from itertools import product
 

--- a/src/mulink/simulate.py
+++ b/src/mulink/simulate.py
@@ -1,0 +1,140 @@
+"""Simulate artificial mudata"""
+
+from itertools import product
+
+import anndata as ad
+import mudata as md
+import networkx as nx
+import numpy as np
+from numpy.random import Generator
+
+
+def _generate_dag(
+    n_level: int = 3,
+    n_vertices: int = 2,
+    *,
+    extra_edge_probability: float | None = 0.2,
+    extra_edge_levels: list[int] | None = None,
+    transitive_closure: bool = True,
+    rng: Generator | None = None,
+) -> tuple[nx.DiGraph, dict[int, int]]:
+    """Generate a hierarchical directed acyclic graph (DAG), starting from a tree.
+
+    Generates a directed acyclic graph, starting from a balanced tree with the desired number of levels.
+    Additional edges can be randomly added to the DAG.
+    Edges between reachable nodes in the graph can be optionally added explicitly (default).
+
+    Parameters
+    ----------
+    n_level
+        Number of levels
+    n_vertices
+        Number of vertices in lowest level
+    extra_edge_probability
+        Probability of drawing an extra edge between vertices from two adjacent topological generations.
+        If `None`, does not add extra edges.
+    extra_edge_levels
+        Topological generations where extra edges are allowed.
+        If None, all levels are eligible.
+    transitive_closure
+        Whether to return a graph where vertices that are indirectly linked are connected with an
+        explicit edge.
+        e.g. for the graph A --> B --> C, the connection A --> C will also be added
+    seed
+        Random seed (for edge addition).
+
+    Returns
+    -------
+    A directed acyclic graph
+    """
+    rng = rng if rng is not None else np.random.default_rng()
+
+    dag = nx.balanced_tree(r=n_vertices, h=n_level, create_using=nx.DiGraph)
+    # Remove root node (extra level)
+    dag.remove_node(0)
+
+    level_to_nodes = dict(enumerate(nx.topological_generations(dag)))
+
+    if extra_edge_probability is not None:
+        # Last level does not have any connections
+        extra_edge_levels = list(range(len(level_to_nodes) - 1)) if extra_edge_levels is None else extra_edge_levels
+
+        for level in extra_edge_levels:
+            for u, v in product(level_to_nodes[level], level_to_nodes[level + 1]):
+                if rng.random() < extra_edge_probability:
+                    dag.add_edge(u, v)
+
+    dag = dag if not transitive_closure else nx.transitive_closure(dag)
+    n_nodes_per_level = {level: len(nodes) for level, nodes in level_to_nodes.items()}
+
+    return dag, n_nodes_per_level
+
+
+def _generate_anndata(n_obs: int, n_var: int, rng: Generator | None = None) -> ad.AnnData:
+    """Generate an anndata object with random values"""
+    rng = rng if rng is not None else np.random.default_rng()
+
+    return ad.AnnData(X=rng.random(size=(n_obs, n_var)))
+
+
+def hierarchical_mudata(
+    n_mod: int,
+    *,
+    n_obs: int = 5,
+    n_vertices: int = 2,
+    extra_edge_probability: float | None = 0.2,
+    extra_edge_levels: list[int] | None = None,
+    transitive_closure: bool = True,
+    varp_key: str = "feature_mapping",
+    random_state: int = 42,
+):
+    """Generate a mudata object with hierarchical feature relationship
+
+    Parameters
+    ----------
+    n_mod
+        Number of modalities (levels) in the object
+    n_obs
+        Number of observations in the object
+    n_vertices
+        Number of vertices in the level with the lowest cardinality
+    extra_edge_probability
+        Probability of adding an additional edge between vertices of adjacent levels.
+        If `None`, the feature relationship between different levels is represented by a tree.
+        This means that a feature from level n+1 maps to exactly one feature in level n
+    extra_edge_levels
+        Constrain the addition of extra edges to these levels of the final mudata object.
+        Must not contain the highest level, as these features do not contain additional connections.
+    transitive_closure
+        Whether to return a graph where features that are indirectly linked are connected with an
+        explicit edge.
+        For example, for the feature mapping A --> B --> C, the connection A --> C will also be added
+    varp_key
+        Name of key that contains the feature mapping in `.varp` attribute of the returned :class:`mudata.MuData`
+        object
+    random_state
+        Random state for the simulation
+    """
+    if any(edge_level > n_mod - 1 for edge_level in extra_edge_levels):
+        raise ValueError("extra_edge_levels must only contain levels from (0..n_mod-1)")
+
+    rng = np.random.default_rng(seed=random_state)
+
+    dag, n_nodes_per_level = _generate_dag(
+        n_level=n_mod,
+        n_vertices=n_vertices,
+        extra_edge_probability=extra_edge_probability,
+        extra_edge_levels=extra_edge_levels,
+        transitive_closure=transitive_closure,
+        rng=rng,
+    )
+
+    mdata = md.MuData(
+        data={
+            f"mod{mod}": _generate_anndata(n_obs=n_obs, n_var=n_nodes_per_level[mod], rng=rng) for mod in range(n_mod)
+        },
+    )
+
+    mdata.varp[varp_key] = nx.adjacency_matrix(dag)
+
+    return mdata

--- a/src/mulink/simulate.py
+++ b/src/mulink/simulate.py
@@ -6,6 +6,7 @@ import anndata as ad
 import mudata as md
 import networkx as nx
 import numpy as np
+import pandas as pd
 from numpy.random import Generator
 
 
@@ -73,11 +74,16 @@ def _generate_dag(
     return dag, n_nodes_per_level
 
 
-def _generate_anndata(n_obs: int, n_var: int, rng: Generator | None = None) -> ad.AnnData:
+def _generate_anndata(
+    n_obs: int, n_var: int, var_prefix: str | None = None, rng: Generator | None = None
+) -> ad.AnnData:
     """Generate an anndata object with random values"""
     rng = rng if rng is not None else np.random.default_rng()
 
-    return ad.AnnData(X=rng.random(size=(n_obs, n_var)))
+    # Make variables unique
+    var = pd.DataFrame(index=[f"{var_prefix}{idx}" for idx in range(n_var)]) if var_prefix is not None else None
+
+    return ad.AnnData(X=rng.random(size=(n_obs, n_var)), var=var)
 
 
 def hierarchical_mudata(
@@ -141,7 +147,8 @@ def hierarchical_mudata(
 
     mdata = md.MuData(
         data={
-            f"mod{mod}": _generate_anndata(n_obs=n_obs, n_var=n_nodes_per_level[mod], rng=rng) for mod in range(n_mod)
+            f"mod{mod}": _generate_anndata(n_obs=n_obs, n_var=n_nodes_per_level[mod], var_prefix=f"mod{mod}-", rng=rng)
+            for mod in range(n_mod)
         },
     )
 

--- a/src/mulink/simulate.py
+++ b/src/mulink/simulate.py
@@ -40,8 +40,8 @@ def _generate_dag(
         Whether to return a graph where vertices that are indirectly linked are connected with an
         explicit edge.
         e.g. for the graph A --> B --> C, the connection A --> C will also be added
-    seed
-        Random seed (for edge addition).
+    rng
+        Random number generator instance.
 
     Returns
     -------

--- a/src/mulink/simulate.py
+++ b/src/mulink/simulate.py
@@ -106,7 +106,7 @@ def hierarchical_mudata(
         If `None`, the feature relationship between different levels is represented by a tree.
         This means that a feature from level n+1 maps to exactly one feature in level n
     extra_edge_levels
-        Constrain the addition of extra edges to these levels of the final mudata object.
+        Constrain the addition of extra edges to these levels of the final mudata object (starting at 0).
         Must not contain the highest level, as these features do not contain additional connections.
     transitive_closure
         Whether to return a graph where features that are indirectly linked are connected with an
@@ -125,8 +125,8 @@ def hierarchical_mudata(
     with `mod{idx}`. The feature mapping is added as adjacency matrix with in the `.varp` attribute as `varp_key`.
     In the matrix, entry (i, j) corresponds to a directed edge from feature i to feature j.
     """
-    if any(edge_level > n_mod - 1 for edge_level in extra_edge_levels):
-        raise ValueError("extra_edge_levels must only contain levels from (0..n_mod-1)")
+    if extra_edge_levels is not None and any(edge_level >= n_mod - 1 for edge_level in extra_edge_levels):
+        raise ValueError("extra_edge_levels must only contain levels from (0..n_mod-2)")
 
     rng = np.random.default_rng(seed=random_state)
 

--- a/src/mulink/simulate.py
+++ b/src/mulink/simulate.py
@@ -45,7 +45,10 @@ def _generate_dag(
 
     Returns
     -------
-    A directed acyclic graph
+    dag
+        A directed acyclic graph
+    n_nodes_per_level
+        Mapping between feature level and number of nodes in this level
     """
     rng = rng if rng is not None else np.random.default_rng()
 
@@ -114,6 +117,13 @@ def hierarchical_mudata(
         object
     random_state
         Random state for the simulation
+
+
+    Returns
+    -------
+    A :class:`mudata.MuData` object with explicit feature mapping. The individual modalities/feature-levels are indicated
+    with `mod{idx}`. The feature mapping is added as adjacency matrix with in the `.varp` attribute as `varp_key`.
+    In the matrix, entry (i, j) corresponds to a directed edge from feature i to feature j.
     """
     if any(edge_level > n_mod - 1 for edge_level in extra_edge_levels):
         raise ValueError("extra_edge_levels must only contain levels from (0..n_mod-1)")

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -1,0 +1,55 @@
+"""Test simulation framework"""
+
+import anndata as ad
+import mudata as md
+import networkx as nx
+import pytest
+
+from mulink.simulate import _generate_anndata, _generate_dag, hierarchical_mudata
+
+md.set_options(pull_on_update=False)
+
+
+@pytest.mark.parametrize(("n_obs", "n_var"), [(0, 0), (1, 2)])
+def test__generate_anndata(n_obs: int, n_var: int) -> None:
+    adata = _generate_anndata(n_obs=n_obs, n_var=n_var)
+
+    assert isinstance(adata, ad.AnnData)
+    assert adata.shape == (n_obs, n_var)
+
+
+@pytest.mark.parametrize("transitive_closure", [True, False])
+@pytest.mark.parametrize("extra_edge_probability", [None, 0, 0.1, 0.9])
+@pytest.mark.parametrize("n_vertices", [1, 2])
+@pytest.mark.parametrize("n_level", [1, 2, 3])
+def test__generate_dag(
+    n_vertices: int, n_level: int, extra_edge_probability: float | None, transitive_closure: bool
+) -> None:
+    dag, n_nodes_per_level = _generate_dag(
+        n_level=n_level,
+        n_vertices=n_vertices,
+        extra_edge_probability=extra_edge_probability,
+        transitive_closure=transitive_closure,
+    )
+
+    expected_nodes_per_level = {level: n_vertices ** (level + 1) for level in range(n_level)}
+
+    assert isinstance(dag, nx.DiGraph)
+    assert nx.is_directed_acyclic_graph(dag)
+    assert n_nodes_per_level == expected_nodes_per_level
+
+
+@pytest.mark.parametrize("varp_key", ["feature_mapping", "test"])
+@pytest.mark.parametrize("n_obs", [5])
+@pytest.mark.parametrize("n_vertices", [1, 3])
+@pytest.mark.parametrize("n_mod", [1, 3])
+def test_hierarchical_mudata(n_mod: int, n_vertices: int, n_obs: int, varp_key: str) -> None:
+    mdata = hierarchical_mudata(n_mod=n_mod, n_vertices=n_vertices, varp_key=varp_key)
+
+    expected_modality_names = {f"mod{idx}" for idx in range(n_mod)}
+    expected_n_vars = sum(n_vertices ** (mod + 1) for mod in range(n_mod))
+
+    assert isinstance(mdata, md.MuData)
+    assert set(mdata.mod.keys()) == expected_modality_names
+    assert mdata.shape == (n_obs, expected_n_vars)
+    assert nx.is_directed_acyclic_graph(nx.from_scipy_sparse_array(mdata.varp[varp_key], create_using=nx.DiGraph))


### PR DESCRIPTION
Adds the generation of synthetic hierarchical data that is conceptually similar to MS-proteomics data. Helped me a bit to understand potential constraints that might be useful in the future

Used a DAG for the implementation, see #4 for some discussions on this

## Usage 
```python
mulink.simulate.hierarchical_mudata(n_mod=3)
# Generates mudata with `mulink` compatible adjacency matrix in `varp["feature_mapping"] 
# and an arbitrary number of feature levels
```

## Implementation 
1. Start from a tree (hierarchical) where each feature from level `n` maps to `n_vertices` in level `n+1`
2. _Optional_ Randomly additional links between nodes from adjacent levels with `extra_edge_probability` (to simulate n:m mapping)
3. _Optional_ Transitive closure. Per default, only nodes from adjacent levels are connected. Transitive closure draws direct edges between all nodes that are _reachable_ between one another.

Minimal graph as example:

```mermaid
flowchart LR
  A --> B --> C
```

with transitive closure 
```mermaid
flowchart LR
  A --> B --> C
  A --> C
```