### PR TITLE
Simulate n vertices

### DIFF
--- a/src/mulink/simulate.py
+++ b/src/mulink/simulate.py
@@ -1,6 +1,6 @@
 """Simulate artificial mudata with explicit feature relationship"""
 
-from itertools import product
+from itertools import count, product
 
 import anndata as ad
 import mudata as md
@@ -13,6 +13,7 @@ from numpy.random import Generator
 def _generate_dag(
     n_level: int = 3,
     n_vertices: int = 2,
+    min_edges: int = 2,
     *,
     extra_edge_probability: float | None = 0.2,
     extra_edge_levels: list[int] | None = None,
@@ -30,7 +31,9 @@ def _generate_dag(
     n_level
         Number of levels
     n_vertices
-        Number of vertices in lowest level
+        Number of vertices at lowest level
+    min_edges
+        Minimum number of edges between vertices
     extra_edge_probability
         Probability of drawing an extra edge between vertices from two adjacent topological generations.
         If `None`, does not add extra edges.
@@ -53,9 +56,13 @@ def _generate_dag(
     """
     rng = rng if rng is not None else np.random.default_rng()
 
-    dag = nx.balanced_tree(r=n_vertices, h=n_level, create_using=nx.DiGraph)
-    # Remove root node (extra level)
-    dag.remove_node(0)
+    dag = nx.DiGraph()
+    subtrees = []
+    for _ in range(n_vertices):
+        subtree = nx.balanced_tree(r=min_edges, h=(n_level - 1), create_using=nx.DiGraph)
+        subtrees.append(subtree)
+
+    dag = nx.union_all(subtrees, rename=count())
 
     level_to_nodes = dict(enumerate(nx.topological_generations(dag)))
 
@@ -91,6 +98,7 @@ def hierarchical_mudata(
     *,
     n_obs: int = 5,
     n_vertices: int = 2,
+    min_edges=2,
     extra_edge_probability: float | None = 0.2,
     extra_edge_levels: list[int] | None = None,
     transitive_closure: bool = True,
@@ -107,6 +115,8 @@ def hierarchical_mudata(
         Number of observations in the object
     n_vertices
         Number of vertices in the level with the lowest cardinality
+    min_edges
+        Minimum number of vertices between adjacent levels
     extra_edge_probability
         Probability of adding an additional edge between vertices of adjacent levels.
         If `None`, the feature relationship between different levels is represented by a tree.
@@ -139,6 +149,7 @@ def hierarchical_mudata(
     dag, n_nodes_per_level = _generate_dag(
         n_level=n_mod,
         n_vertices=n_vertices,
+        min_edges=min_edges,
         extra_edge_probability=extra_edge_probability,
         extra_edge_levels=extra_edge_levels,
         transitive_closure=transitive_closure,

--- a/src/mulink/simulate.py
+++ b/src/mulink/simulate.py
@@ -1,6 +1,6 @@
 """Simulate artificial mudata with explicit feature relationship"""
 
-from itertools import count, product
+from itertools import product
 
 import anndata as ad
 import mudata as md
@@ -62,7 +62,7 @@ def _generate_dag(
         subtree = nx.balanced_tree(r=min_edges, h=(n_level - 1), create_using=nx.DiGraph)
         subtrees.append(subtree)
 
-    dag = nx.union_all(subtrees, rename=count())
+    dag = nx.union_all(subtrees, rename=(f"{idx}-" for idx in range(n_vertices)))
 
     level_to_nodes = dict(enumerate(nx.topological_generations(dag)))
 
@@ -163,6 +163,8 @@ def hierarchical_mudata(
         },
     )
 
-    mdata.varp[varp_key] = nx.adjacency_matrix(dag)
+    # Ensure that the adjacency matrix is stored in topological order, so that nodes belonging to highest priority mod
+    # are coming up first, etc.
+    mdata.varp[varp_key] = nx.adjacency_matrix(dag, nodelist=list(nx.topological_sort(dag)))
 
     return mdata

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -20,20 +20,21 @@ def test__generate_anndata(n_obs: int, n_var: int) -> None:
 
 @pytest.mark.parametrize("transitive_closure", [True, False])
 @pytest.mark.parametrize("extra_edge_probability", [None, 0, 0.1, 0.9])
-@pytest.mark.parametrize("n_vertices", [1, 2])
+@pytest.mark.parametrize("min_edges", [1, 2, 3])
+@pytest.mark.parametrize("n_vertices", [1, 3, 10])
 @pytest.mark.parametrize("n_level", [1, 2, 3])
 def test__generate_dag(
-    n_vertices: int, n_level: int, extra_edge_probability: float | None, transitive_closure: bool
+    n_vertices: int, min_edges: int, n_level: int, extra_edge_probability: float | None, transitive_closure: bool
 ) -> None:
     dag, n_nodes_per_level = _generate_dag(
         n_level=n_level,
         n_vertices=n_vertices,
-        min_edges=n_vertices,
+        min_edges=min_edges,
         extra_edge_probability=extra_edge_probability,
         transitive_closure=transitive_closure,
     )
 
-    expected_nodes_per_level = {level: n_vertices ** (level + 1) for level in range(n_level)}
+    expected_nodes_per_level = {level: n_vertices * min_edges**level for level in range(n_level)}
 
     assert isinstance(dag, nx.DiGraph)
     assert nx.is_directed_acyclic_graph(dag)
@@ -42,13 +43,14 @@ def test__generate_dag(
 
 @pytest.mark.parametrize("varp_key", ["feature_mapping", "test"])
 @pytest.mark.parametrize("n_obs", [5])
-@pytest.mark.parametrize("n_vertices", [1, 3])
+@pytest.mark.parametrize("min_edges", [1, 2, 3])
+@pytest.mark.parametrize("n_vertices", [1, 3, 10])
 @pytest.mark.parametrize("n_mod", [1, 3])
-def test_hierarchical_mudata(n_mod: int, n_vertices: int, n_obs: int, varp_key: str) -> None:
-    mdata = hierarchical_mudata(n_mod=n_mod, n_vertices=n_vertices, min_edges=n_vertices, varp_key=varp_key)
+def test_hierarchical_mudata(n_mod: int, n_vertices: int, min_edges: int, n_obs: int, varp_key: str) -> None:
+    mdata = hierarchical_mudata(n_mod=n_mod, n_vertices=n_vertices, min_edges=min_edges, varp_key=varp_key)
 
     expected_modality_names = {f"mod{idx}" for idx in range(n_mod)}
-    expected_n_vars = sum(n_vertices ** (mod + 1) for mod in range(n_mod))
+    expected_n_vars = sum(n_vertices * min_edges**mod for mod in range(n_mod))
 
     assert isinstance(mdata, md.MuData)
     assert set(mdata.mod.keys()) == expected_modality_names

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -28,6 +28,7 @@ def test__generate_dag(
     dag, n_nodes_per_level = _generate_dag(
         n_level=n_level,
         n_vertices=n_vertices,
+        min_edges=n_vertices,
         extra_edge_probability=extra_edge_probability,
         transitive_closure=transitive_closure,
     )
@@ -44,7 +45,7 @@ def test__generate_dag(
 @pytest.mark.parametrize("n_vertices", [1, 3])
 @pytest.mark.parametrize("n_mod", [1, 3])
 def test_hierarchical_mudata(n_mod: int, n_vertices: int, n_obs: int, varp_key: str) -> None:
-    mdata = hierarchical_mudata(n_mod=n_mod, n_vertices=n_vertices, varp_key=varp_key)
+    mdata = hierarchical_mudata(n_mod=n_mod, n_vertices=n_vertices, min_edges=n_vertices, varp_key=varp_key)
 
     expected_modality_names = {f"mod{idx}" for idx in range(n_mod)}
     expected_n_vars = sum(n_vertices ** (mod + 1) for mod in range(n_mod))


### PR DESCRIPTION
Makes sure that the number of features/vertices and number of edges between features are independent by using union of `n_vertices` balanced trees instead 1 balanced tree

Before that, the number of features  was scaling was exponentially with respect to the number of features in modality 0 with ( $F(m) = F^{(m+1)}$ ) with every hierarchy level $m$. Now it is scaling with $F(m)=F_0 * r^m$ with $r<<F_0$. 