### PR TITLE
[Feature] Query specific modalities

### DIFF
--- a/docs/notebooks/example.ipynb
+++ b/docs/notebooks/example.ipynb
@@ -271,7 +271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get a specific modality level, you can use the standard `mudata` query:"
+    "You can also only query for features of a specific modality, so that only this modality is included in the result:"
    ]
   },
   {
@@ -281,11 +281,51 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<pre>View of MuData object with n_obs × n_vars = 5 × 1\n",
+       "  varp:\t&#x27;feature_mapping&#x27;\n",
+       "  3 modalities\n",
+       "    mod0:\t5 × 0\n",
+       "    mod1:\t5 × 1\n",
+       "    mod2:\t5 × 0</pre>"
+      ],
+      "text/plain": [
+       "View of MuData object with n_obs × n_vars = 5 × 1\n",
+       "  varp:\t'feature_mapping'\n",
+       "  3 modalities\n",
+       "    mod0:\t5 × 0\n",
+       "    mod1:\t5 × 1\n",
+       "    mod2:\t5 × 0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mdata.link.query.ancestors(features=[\"mod2-1\"], include_mods=[\"mod1\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To extract a specific modality level, you can use the standard `mudata` query:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
       "text/plain": [
        "AnnData object with n_obs × n_vars = 5 × 1"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/src/mulink/basic.py
+++ b/src/mulink/basic.py
@@ -16,7 +16,7 @@ class MuLink:
         - pl: Plotting functionalities
     """
 
-    def __init__(self, mdata: md.MuData):
+    def __init__(self, mdata: md.MuData) -> None:
         self._obj = mdata
 
     def add_link(self, link: csr_matrix, *, key: str = "feature_mapping") -> None:

--- a/src/mulink/plotting.py
+++ b/src/mulink/plotting.py
@@ -18,7 +18,7 @@ def _modality_limits(mdata: md.MuData) -> np.ndarray:
 class PlotAccessor:
     """Plotting accessor for mulink"""
 
-    def __init__(self, link):
+    def __init__(self, link) -> None:
         self._link = link
         self._mdata = self._link._obj
 

--- a/src/mulink/query.py
+++ b/src/mulink/query.py
@@ -25,7 +25,6 @@ def get_descendants(vertices: int | Iterable[int], adjacency_matrix: csr_matrix)
     Returns
     -------
     List of successors of the provided vertices
-    Direct successors of the provided vertices
     """
     vertices = [vertices] if isinstance(vertices, int) else vertices
 
@@ -51,7 +50,6 @@ def get_ancestors(vertices: int | Iterable[int], adjacency_matrix: csr_matrix) -
     Returns
     -------
     List of ancestors of the provided vertices
-    Direct ancestors of the provided vertices
     """
     vertices = [vertices] if isinstance(vertices, int) else vertices
 

--- a/src/mulink/query.py
+++ b/src/mulink/query.py
@@ -1,6 +1,6 @@
 """Query an adjacency matrix"""
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 
 import mudata as md
 import numpy as np
@@ -25,6 +25,7 @@ def get_descendants(vertices: int | Iterable[int], adjacency_matrix: csr_matrix)
     Returns
     -------
     List of successors of the provided vertices
+    Direct successors of the provided vertices
     """
     vertices = [vertices] if isinstance(vertices, int) else vertices
 
@@ -50,6 +51,7 @@ def get_ancestors(vertices: int | Iterable[int], adjacency_matrix: csr_matrix) -
     Returns
     -------
     List of ancestors of the provided vertices
+    Direct ancestors of the provided vertices
     """
     vertices = [vertices] if isinstance(vertices, int) else vertices
 
@@ -69,6 +71,28 @@ def get_ancestors(vertices: int | Iterable[int], adjacency_matrix: csr_matrix) -
     return np.unique(ancestors)
 
 
+def filter_modality_members(vertices: Iterable[int], varmap: Mapping, mods: Iterable[str]) -> np.ndarray:
+    """Filter for all vertices that are member in a modality
+
+    Parameters
+    ----------
+    vertices
+        Global integer position of vertix in mdata object
+    varmap
+        mudata varmap
+    modalities
+        Modalities to consider
+
+    Returns
+    -------
+    Vertices that are members of the provided modalities
+    """
+    # Flatten as varmap is a 1d array
+    allowed_indices = np.concatenate([np.flatnonzero(varmap[mod]) for mod in mods])
+
+    return vertices[np.isin(vertices, allowed_indices)]
+
+
 class QueryAccessor:
     """Query functionality for mulink"""
 
@@ -83,6 +107,7 @@ class QueryAccessor:
         *,
         key: str = "feature_mapping",
         include_self: bool = True,
+        mods: str | list[str] | None = None,
     ) -> md.MuData:
         adjacency_matrix = self._mdata.varp[key]
 
@@ -94,6 +119,10 @@ class QueryAccessor:
         if include_self:
             result_indices = np.union1d(result_indices, query_indices)
 
+        if mods is not None:
+            mods = [mods] if isinstance(mods, str) else mods
+            result_indices = filter_modality_members(vertices=result_indices, varmap=self._mdata.varmap, mods=mods)
+
         return self._mdata[:, self._mdata.var_names[result_indices]]
 
     def descendants(
@@ -102,8 +131,22 @@ class QueryAccessor:
         *,
         key: str = "feature_mapping",
         include_self: bool = True,
+        include_mods: str | list[str] | None = None,
     ) -> md.MuData:
         """Get descendants of features
+
+        Parameters
+        ----------
+        features
+            Features to query for
+        key
+            Key in `mdata.varm` that represents the mulink graph
+        include_self
+            Whether to include the query features in the results.
+        include_mods
+            Only include features from the provided `mdata.mods` in the results.
+            If `None`, includes members of all modalities.
+
 
         Examples
         --------
@@ -117,10 +160,7 @@ class QueryAccessor:
 
         """
         return self._query(
-            query_func=get_descendants,
-            features=features,
-            key=key,
-            include_self=include_self,
+            query_func=get_descendants, features=features, key=key, include_self=include_self, mods=include_mods
         )
 
     def ancestors(
@@ -129,8 +169,21 @@ class QueryAccessor:
         *,
         key: str = "feature_mapping",
         include_self: bool = True,
+        include_mods: str | list[str] | None = None,
     ) -> md.MuData:
         """Get ancestors of features
+
+        Parameters
+        ----------
+        features
+            Features to query for
+        key
+            Key in `mdata.varm` that represents the mulink graph
+        include_self
+            Whether to include the query features in the results.
+        include_mods
+            Only include features from the provided `mdata.mods` in the results.
+            If `None`, includes members of all modalities.
 
         Examples
         --------
@@ -144,8 +197,5 @@ class QueryAccessor:
 
         """
         return self._query(
-            query_func=get_ancestors,
-            features=features,
-            key=key,
-            include_self=include_self,
+            query_func=get_ancestors, features=features, key=key, include_self=include_self, mods=include_mods
         )

--- a/src/mulink/query.py
+++ b/src/mulink/query.py
@@ -96,7 +96,7 @@ def filter_modality_members(vertices: Iterable[int], varmap: Mapping, mods: Iter
 class QueryAccessor:
     """Query functionality for mulink"""
 
-    def __init__(self, link):
+    def __init__(self, link) -> None:
         self._link = link
         self._mdata = self._link._obj
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,7 +4,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import mulink  # noqa: F401 — registers the namespace
-from mulink.query import get_ancestors, get_descendants
+from mulink.query import filter_modality_members, get_ancestors, get_descendants
 
 
 @pytest.fixture
@@ -66,6 +66,31 @@ class TestGetAncestors:
         assert_array_equal(result, expected_result_indices)
 
 
+class TestFilterModalityMembers:
+    """Test that modality member filtering works correctly"""
+
+    @pytest.mark.parametrize(
+        ("vertices", "modalities", "expected_results"),
+        [
+            (np.array([0, 1, 2, 3]), ["rna", "prot"], np.array([0, 1, 2, 3])),  # Keep all, explicit
+            (np.array([0, 1, 2, 3]), ["rna"], np.array([0, 1])),  # Keep RNA only (first modality)
+            (np.array([0, 1, 2, 3]), ["prot"], np.array([2, 3])),  # Keep Proteins only (second modality)
+            (np.array([0]), ["rna"], np.array([0])),  # Feature is in modality
+            (np.array([0]), ["prot"], np.array([])),  # Feature is not in modality
+        ],
+    )
+    def test_filter_modality_members(
+        self,
+        simple_mudata: md.MuData,
+        vertices: np.ndarray,
+        modalities: str | list[str] | None,
+        expected_results: np.ndarray,
+    ) -> None:
+        result = filter_modality_members(vertices=vertices, varmap=simple_mudata.varmap, mods=modalities)
+
+        assert_array_equal(result, expected_results)
+
+
 class TestQueryDescendants:
     def test_single_feature_string(self, simple_mudata) -> None:
         result = simple_mudata.link.query.descendants("gene_A")
@@ -107,6 +132,25 @@ class TestQueryDescendants:
 
         assert_array_equal(sorted(result.var_names), ["prot_C", "prot_D"])
 
+    @pytest.mark.parametrize(
+        ("query", "mods", "expected_features"),
+        [
+            # Default (all)
+            (["gene_A", "gene_B"], None, ["gene_A", "gene_B", "prot_C", "prot_D"]),
+            # Default (explicit)
+            (["gene_A", "gene_B"], ["rna", "prot"], ["gene_A", "gene_B", "prot_C", "prot_D"]),
+            # Protein only
+            (["gene_A", "gene_B"], ["prot"], ["prot_C", "prot_D"]),
+            # RNA only
+            (["gene_A", "gene_B"], ["rna"], ["gene_A", "gene_B"]),
+        ],
+    )
+    def test_restricted_mods(self, simple_mudata, query, mods, expected_features) -> None:
+        """Test that only specific modalities can be returned"""
+        result = simple_mudata.link.query.descendants(query, include_self=True, include_mods=mods)
+
+        assert_array_equal(sorted(result.var_names), expected_features)
+
 
 class TestQueryAncestors:
     def test_single_feature(self, simple_mudata):
@@ -143,3 +187,22 @@ class TestQueryAncestors:
         result = n_to_m_mudata.link.query.ancestors("prot_D", include_self=False)
 
         assert_array_equal(sorted(result.var_names), ["gene_A", "gene_B"])
+
+    @pytest.mark.parametrize(
+        ("query", "mods", "expected_features"),
+        [
+            # Default (all)
+            ("prot_C", None, ["gene_A", "prot_C"]),
+            # Default (explicit)
+            ("prot_C", ["rna", "prot"], ["gene_A", "prot_C"]),
+            # Protein only
+            ("prot_C", ["prot"], ["prot_C"]),
+            # RNA only
+            ("prot_C", ["rna"], ["gene_A"]),
+        ],
+    )
+    def test_restricted_mods(self, simple_mudata, query, mods, expected_features) -> None:
+        """Test that only specific modalities can be returned"""
+        result = simple_mudata.link.query.ancestors(query, include_self=True, include_mods=mods)
+
+        assert_array_equal(sorted(result.var_names), expected_features)


### PR DESCRIPTION
Only include specific modalities in the query result. 

## Example

<img width="250" alt="graph" src="https://github.com/user-attachments/assets/a0f9aed5-ae98-4c08-b481-b486ef02b57c" />

```python
mdata.link.query.ancestors(features=["mod2-1"])
View of MuData object with n_obs × n_vars = 5 × 3
  varp:	'feature_mapping'
  3 modalities
    mod0:	5 × 1
    mod1:	5 × 1
    mod2:	5 × 1
# Returns all ancestors across all modalities
```

Newly enabled feature:
```python
mdata.link.query.ancestors(features=["mod2-1"], include_mods=["mod1"])
View of MuData object with n_obs × n_vars = 5 × 1
  varp:	'feature_mapping'
  3 modalities
    mod0:	5 × 0
    mod1:	5 × 1
    mod2:	5 × 0
# Only return features from modality 1
```