### PR TITLE
Fix dtype error in linkage matrix

### DIFF
--- a/src/mulink/basic.py
+++ b/src/mulink/basic.py
@@ -31,8 +31,9 @@ class MuLink:
         key
             Key of feature mapping matrix in `.varp` to use.
         """
-        return pd.DataFrame.sparse.from_spmatrix(
-            self._obj.varp[key], index=self._obj.var_names, columns=self._obj.var_names
+        matrix = self._obj.varp[key]
+        return pd.DataFrame.sparse.from_spmatrix(matrix, index=self._obj.var_names, columns=self._obj.var_names).astype(
+            pd.SparseDtype(matrix.dtype, fill_value=0)
         )
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,8 +69,8 @@ def n_to_m_mudata() -> md.MuData:
     return mdata
 
 
-@pytest.fixture
-def simple_hierarchical_mudata() -> md.MuData:
+@pytest.fixture(params=[{"linkage_dtype": np.int32}, {"linkage_dtype": np.float64}])
+def simple_hierarchical_mudata(request) -> md.MuData:
     """MuData with 3 hierarchical levels A->B->C"""
     level0 = ad.AnnData(
         X=np.array([[1], [2]]),
@@ -92,5 +92,7 @@ def simple_hierarchical_mudata() -> md.MuData:
 
     mdata = md.MuData({"level0": level0, "level1": level1, "level2": level2})
     # var_names: [A, B, C, D, E, F]
-    mdata.varp["feature_mapping"] = csr_matrix(np.array([[0, 1, 0], [0, 0, 1], [0, 0, 0]]))
+    mdata.varp["feature_mapping"] = csr_matrix(
+        np.array([[0, 1, 0], [0, 0, 1], [0, 0, 0]], dtype=request.param["linkage_dtype"])
+    )
     return mdata


### PR DESCRIPTION
If the linkage matrix is float, `mulink` interprets resulting `NA` values in the linkage matrix as links. Fix by enforcing missing values with 0 fill.